### PR TITLE
Bugfix to make the icon appear in the shortcut button

### DIFF
--- a/jupyter_launcher_shortcuts/api.py
+++ b/jupyter_launcher_shortcuts/api.py
@@ -18,6 +18,7 @@ class ShortcutsHandler(IPythonHandler):
             }
             if ls.icon_path:
                 icon_url = ujoin(self.base_url, 'launcher-shortcuts', 'icon', ls.name)
+                item['icon_url'] = icon_url
             data.append(item)
 
         self.write({'shortcuts': data})


### PR DESCRIPTION
Without this change, the svg image is ignored and will not show up in the jupyterlab launcher page.