### PR TITLE
Jupyterlab 3 validation

### DIFF
--- a/jupyterlab-launcher-shortcuts/package.json
+++ b/jupyterlab-launcher-shortcuts/package.json
@@ -30,8 +30,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^2.0.0",
-    "@jupyterlab/launcher": "^2.0.0"
+    "@jupyterlab/application": "^3.0.0",
+    "@jupyterlab/launcher": "^3.0.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Dear @yuvipanda 

Since Jupyterlab 3 release, this extension can't be installed (#12)

After some tests with jupyterlab 3.0.0 and 3.0.16, it seems that the extension is fully compatible with Jupyterlab3+. Moreover, a quick read of ILauncher doesn't highlight any compatibility problems.

I've lead simple tests with 

- jupyterlab==3.0.16 and jupyterlab==3.0.0
- NodeJS 14.17.0

Many thanks for this extension which permits us to propose a clickable VDI experience from jupyterhub. 
Tristan