### PR TITLE
Add missing LICENSE file to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setuptools.setup(
     author="Yuvi Panda",
     author_email="yuvipanda@gmail.com",
     license="BSD 3-Clause",
+    license_files = ("LICENSE",),
     description="Easily place shortcuts",
     packages=setuptools.find_packages(),
     install_requires=['notebook', 'simpervisor', 'aiohttp'],


### PR DESCRIPTION
...so that it gets bundled in the sdist

I'm making a conda-forge feedstock for this, but the LICENSE file is missing from the PyPI sdist.