### PR TITLE
Fix handling of icons

### DIFF
--- a/jupyter_launcher_shortcuts/api.py
+++ b/jupyter_launcher_shortcuts/api.py
@@ -17,7 +17,7 @@ class ShortcutsHandler(IPythonHandler):
                 'target': ls.target.format(base_url=self.base_url),
             }
             if ls.icon_path:
-                icon_url = ujoin(self.base_url, 'launcher-shortcuts', 'icon', ls.name)
+                item["icon_url"] = ujoin(self.base_url, 'launcher-shortcuts', 'icon', ls.name)
             data.append(item)
 
         self.write({'shortcuts': data})
@@ -55,6 +55,6 @@ class IconHandler(IPythonHandler):
         else:
             content_type = "application/octet-stream"
 
-        with open(self.icons[name]) as f:
+        with open(self.icons[name], "rb") as f:
             self.write(f.read())
         self.set_header('Content-Type', content_type)


### PR DESCRIPTION
This PR fixes a few issues:

- When an icon is specified, it was not actually returned by the API.
- Icon files should be read with `rb`, to avoid:

```
    Traceback (most recent call last):
      File "/opt/venv/python3.7/lib/python3.7/site-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File "/opt/venv/python3.7/lib/python3.7/site-packages/jupyter_launcher_shortcuts/api.py", line 59, in get
        self.write(f.read())
      File "/opt/miniconda3/lib/python3.7/codecs.py", line 322, in decode
        (result, consumed) = self._buffer_decode(data, self.errors, final)
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```

- Links were assigned to the "Notebook" category, but links are by definition not notebooks. I have update the category to "Other" which seems more appropriate.

Thanks for the useful extension @yuvipanda!